### PR TITLE
Fixed a bug where '0' in an if() would result in false

### DIFF
--- a/src/Formatter/NumberFormatter.php
+++ b/src/Formatter/NumberFormatter.php
@@ -201,7 +201,7 @@ class NumberFormatter implements NumberFormatterInterface
         }
 
         // Assemble the final number and insert it into the pattern.
-        $value = $minorDigits ? $majorDigits . '.' . $minorDigits : $majorDigits;
+        $value = strlen($minorDigits) ? $majorDigits . '.' . $minorDigits : $majorDigits;
         $pattern = $negative ? $this->negativePattern : $this->positivePattern;
         $value = preg_replace('/#(?:[\.,]#+)*0(?:[,\.][0#]+)*/', $value, $pattern);
 


### PR DESCRIPTION
$value = $minorDigits ? $majorDigits . '.' . $minorDigits : $majorDigits;

$minorDigits = '0';

in this case if ($minorDigits) would return false.

to test this:

        if ('0') {
            die('true'));
        } else {
            die('false'));
        }